### PR TITLE
lein-midje-doc will not run without option "plain"

### DIFF
--- a/src/leiningen/midje_doc.clj
+++ b/src/leiningen/midje_doc.clj
@@ -52,8 +52,8 @@
   [project & args]
   (let [opts (set args)
         project (if (or (opts "plain") (check-pygmentize))
-                  (assoc-in project [:documentation :plain] true))]
-
+                  (assoc-in project [:documentation :plain] true)
+                  project)]
     (if (opts "once")
       (process-once project)
       (do


### PR DESCRIPTION
Just wanted to check your plugin out and since nothing was generated, even when I tried it with the lein-midje-doc project itself, I went on a (really small) expedition into your code and fixed this small bug.

Also, I'm really looking forward to some of the features on the wishlist, e.g. single-page generation, markdown rendering and themes. Great job so far!
