### PR TITLE
Let 'plain' option actually produce plain output.

### DIFF
--- a/src/leiningen/midje_doc.clj
+++ b/src/leiningen/midje_doc.clj
@@ -51,7 +51,7 @@
   "I don't do a lot."
   [project & args]
   (let [opts (set args)
-        project (if (or (opts "plain") (check-pygmentize))
+        project (if (or (opts "plain") (not (check-pygmentize)))
                   (assoc-in project [:documentation :plain] true)
                   project)]
     (if (opts "once")

--- a/src/leiningen/midje_doc/renderer.clj
+++ b/src/leiningen/midje_doc/renderer.clj
@@ -66,11 +66,11 @@
        [:h4 [:i (str "e." (:num elem)
                      (if-let [t (:title elem)] (str "  &nbsp;-&nbsp; " t)))]])
      (if *plain*
-       (pygmentize  "-f" "html" "-l" (or (:lang elem) "clojure")
-                    {:in (adjust-indented-code (:content elem)
-                                               (apply str (repeat (or (:fact-level elem) 0) "  ")))})
        [:pre (adjust-indented-code (:content elem)
-                                   (apply str (repeat (or (:fact-level elem) 0) "  ")))])]))
+                                   (apply str (repeat (or (:fact-level elem) 0) "  ")))]
+       (pygmentize  "-f" "html" "-l" (or (:lang elem) "clojure")
+                   {:in (adjust-indented-code (:content elem)
+                                              (apply str (repeat (or (:fact-level elem) 0) "  ")))}))]))
 
 
 (defn render-toc-element [elem]


### PR DESCRIPTION
As discussed in #1, this pull request fixes the handling of the command line option `plain` (and the subsequent use of the affected var `*plain*`). I'll have a look at escaping the contents of the `<pre>` blocks if you want to. Should be possible with something like:

``` clojure
(clojure.string/escape "<title>" { \< "&lt;" \> "&gt;" \& "&amp;" })
;; => "&lt;title&gt;"
```

That would remove most problematic cases, I guess.
