### PR TITLE
Quick fix of a bug in the first tutorial example

### DIFF
--- a/test/midje_doc/midje_doc_guide.clj
+++ b/test/midje_doc/midje_doc_guide.clj
@@ -86,7 +86,7 @@
   "`add-5` outputs the following results seen in
  [e.{{add-5-1}}](#add-5-1) and [e.{{add-5-10}}](#add-5-10):"
 
-  (fact
+  (facts
     [[{:tag "add-5-1" :title "1 add 5 = 6"}]]
     (add-5 1) => 6
 


### PR DESCRIPTION
Took me a while to figure out this little detail.
Rendering of the tag only works if you use "facts" instead of "fact" when enumerating facts. Even when it's only one fact.
